### PR TITLE
Replace character length with line length.

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -16,7 +16,7 @@
 
 
 ## Auto-formatters
-* Use [black](https://github.com/psf/black/) with default settings (max character length 88 lines).
+* Use [black](https://github.com/psf/black/) with default settings (max line length 88 characters).
 * Use [flake8](https://github.com/PyCQA/flake8) to catch linting errors.
 * Use [isort](https://github.com/timothycrosley/isort) to sort the imports.
 


### PR DESCRIPTION
This reads a little oddly to me.  I think it should either say "max line length 88 characters" or "max characters per line 88."  Suggesting the first as it mostly closely fits with your original wording.